### PR TITLE
Changes things to be a bit more idiomatic about asyncio.

### DIFF
--- a/khoutsider.py
+++ b/khoutsider.py
@@ -1,91 +1,98 @@
 import argparse
 import asyncio
+import functools
+
 import aiohttp
-import nest_asyncio
-nest_asyncio.apply()
 from requests.utils import unquote
+from requests_html import HTMLResponse, HTMLSession, AsyncHTMLSession
 
-from requests_html import HTMLSession, AsyncHTMLSession
 
-async def download_file(url, verbose:bool = False):
-  async with aiohttp.ClientSession() as session:
+async def download_file(
+    url: str, session: aiohttp.ClientSession, verbose: bool = False
+) -> None:
     async with session.get(url) as response:
-      if "content-disposition" in response.headers:
-        header = response.headers["content-disposition"]
-        filename = header.split("filename=")[1]
-      else:
-        filename = url.split("/")[-1]
+        if "content-disposition" in response.headers:
+            header = response.headers["content-disposition"]
+            filename = header.split("filename=")[1]
+        else:
+            filename = url.split("/")[-1]
 
-      filename = unquote(filename)
-      with open(filename, mode="wb") as file:
-        while True:
-          chunk = await response.content.read()
-          if not chunk:
-            break
-          file.write(chunk)
-        if verbose:
-          print(f"Downloaded file {filename}")
+        filename = unquote(filename)
+        with open(filename, mode="wb") as file:
+            # 10 MB chunks
+            async for chunk in response.content.iter_chunked(1024 * 1024 * 10):
+                file.write(chunk)
+            if verbose:
+                print(f"Downloaded file {filename}")
 
-async def main(args):
-  def print_if_verbose(msg):
-    if args.verbose:
-      print(msg)
 
-  url = args.url
+async def main(args: argparse.Namespace) -> None:
 
-  session = HTMLSession()
-  r = session.get(url)
-  print_if_verbose("Obtained list URL...")
-  asession = AsyncHTMLSession()
+    def print_if_verbose(msg: str) -> None:
+        if args.verbose:
+            print(msg)
 
-  async def get_url(url):
-    return await asession.get(url)
+    url = args.url
 
-  track_links = []
-  tasks = []
-  if not r.raise_for_status():
-    print_if_verbose("Obtained URL for " + r.html.find('h2', first=True).text)
-    info_paragraph = r.html.find('p[align="left"]',first=True).text.splitlines()
-    for line in info_paragraph:
-      if 'Number of Files' in line:
-        track_count = int(line.split(':')[-1])
+    session = HTMLSession()
+    r = session.get(url)
+    print_if_verbose("Obtained list URL...")
+    asession = AsyncHTMLSession(loop=asyncio.get_running_loop())
 
-    print_if_verbose(f"{track_count} songs available")
+    async def get_url(url: str) -> HTMLResponse:
+        return await asession.get(url)
 
-    table = [min(x.absolute_links) for x in r.html.find('#songlist .playlistDownloadSong')]
-    track_links = [lambda url=url: get_url(url) for url in table]
+    track_links = []
+    if not r.raise_for_status():
+        print_if_verbose("Obtained URL for " + r.html.find("h2", first=True).text)
+        info_paragraph = r.html.find('p[align="left"]', first=True).text.splitlines()
+        for line in info_paragraph:
+            if "Number of Files" in line:
+                track_count = int(line.split(":")[-1])
 
-  r = asession.run(*track_links)
-  flac_possible = True
-  for result in r:
-    if args.prefer_flac and flac_possible:
-      audio = [x for x in list(result.html.absolute_links) if '.flac' in x]
-      if not audio and flac_possible:
-        flac_possible = False
-        print("No FLAC files available, defaulting to mp3...")
-        audio = result.html.find('audio', first=True).attrs['src']
-      else:
-        audio = audio[-1]
-    else:
-      audio = result.html.find('audio', first=True).attrs['src']
-    tasks.append(download_file(audio,args.verbose))
+        print_if_verbose(f"{track_count} songs available")
 
-  await asyncio.gather(*tasks)
-  
+        table = [
+            min(x.absolute_links)
+            for x in r.html.find("#songlist .playlistDownloadSong")
+        ]
+        track_links = [functools.partial(get_url, url) for url in table]
+
+    r = []
+    async with asyncio.TaskGroup() as tg:
+        for track in track_links:
+            r.append(tg.create_task(track()))
+    flac_possible = True
+    async with aiohttp.ClientSession() as download_session, asyncio.TaskGroup() as tg:
+        for result in (t.result() for t in r):
+            if args.prefer_flac and flac_possible:
+                audio = [x for x in list(result.html.absolute_links) if ".flac" in x]
+                if not audio and flac_possible:
+                    flac_possible = False
+                    print("No FLAC files available, defaulting to mp3...")
+                    audio = result.html.find("audio", first=True).attrs["src"]
+                else:
+                    audio = audio[-1]
+            else:
+                audio = result.html.find("audio", first=True).attrs["src"]
+            tg.create_task(download_file(audio, download_session, args.verbose))
+
+
 if __name__ == "__main__":
-  parser = argparse.ArgumentParser(
-                      prog='KHOutsider',
-                      description='Automatically download a full album from KHInsider',
-                      epilog='Enjoy the tunes!')
-                        
-  parser.add_argument('url', help="URL with the album tracklist")
-  parser.add_argument('-v', '--verbose',
-                        action='store_true') 
-  parser.add_argument('--prefer-flac',
-                      action='store_true',
-                      help="download FLAC files over MP3 if available")
+    parser = argparse.ArgumentParser(
+        prog="KHOutsider",
+        description="Automatically download a full album from KHInsider",
+        epilog="Enjoy the tunes!",
+    )
 
-  args = parser.parse_args()
+    parser.add_argument("url", help="URL with the album tracklist")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument(
+        "--prefer-flac",
+        action="store_true",
+        help="download FLAC files over MP3 if available",
+    )
 
-  asyncio.run(main(args))
-  
+    args = parser.parse_args()
+
+    asyncio.run(main(args))


### PR DESCRIPTION
* removes nested loops by handling tasks ourself instead of asession.run.
* reuse the aiohttp session object, as recommended in the aiohttp docs.
* use the streaming example from the aiohttp docs with 10MB chunks.
* asyncio.gather -> asyncio.TaskGroup.
* formatting with black.
* some typing.